### PR TITLE
Fix E-Core detection logic for i5-12600K

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 CpuTopologyRebuild Changelog
 ===================
+#### v1.0.2
+- Fixed E-Core detection logic for i5-12600K ( #7 )
+
 #### v1.0.1
 - Fixed patching logic to work with Lilu 1.6.0 ( #5 )
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CpuTopologyRebuild
-A Lilu plugin that optimizes Alder Lake's heterogeneous core configuration.
+An **experimental** Lilu plugin that optimizes Alder Lake's heterogeneous core configuration.
 
 For example, this kext is possible to recognize the Core i9-12900K's topology as 16 cores 24 threads or 8 cores 24 threads.
 
@@ -8,7 +8,8 @@ OpenCore's `ProvideCurrentCpuInfo` quirk enables Alder Lake's both P-Cores and E
 
 This kext aims to improve performance by rebuild the topology for these cores and threads.
 
-The effect of this kext is not yet clear, but I've seen not only a cosmetic effect, but also some performance improvements. For example, the Geekbench 5 score on the Windows VM have increased in the case of allocating a small number of cores to VMware Fusion.
+The effect of this kext is not yet clear, but I've seen not only a cosmetic effect, but also some performance improvements. For example, the Geekbench 5 score on the Windows VM have increased in the case of allocating a small number of cores to VMware Fusion.  
+Other examples : https://github.com/b00t0x/CpuTopologyRebuild/wiki/%E3%83%91%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%B3%E3%82%B9%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%8E%A8%E5%AF%9F (Japanese)
 
 ### Usage
 * Use this kext with `ProvideCurrentCpuInfo` quirk.
@@ -31,6 +32,8 @@ patches.plist can be used instead of `ProvideCurrentCpuInfo` quirk. It is not ne
 ### Current problems
 * Changing the number of cores in cpuid info causes instability such as random boot failing, so it has not been changed now. Therefore, the number of cores and threads changes can be seen only in limited situations such as a Geekbench result window.
 * For the same reason, RestrictEvents.kext's `revcpuname` does not work because the number of cores recognized by RestrictEvents.kext and About This Mac window are different. I added the [modded RestrictEvents.kext](https://github.com/b00t0x/CpuTopologyRebuild/releases/download/1.0.0/RestrictEvents-1.0.6-RELEASE.zip) with [a temporary fix](https://gist.github.com/b00t0x/a13cefd4644e9d6d57908ce3420c3002#file-restrictevents-cpp-diff) to solve the issue.
+  * This issue expected to be [fixed](https://github.com/acidanthera/RestrictEvents/pull/6) in RestrictEvents.kext 1.0.7.
+* Untested with Core i7-12xxx.
 
 ### Credits
 - [Apple](https://www.apple.com) for macOS


### PR DESCRIPTION
fix #6.

The kext assumed E-Core's LapicId is 64 or higher, but i5 has E-Cores LapicId start from 56. This PR fix the E-Core detection logic.