### PR TITLE
v2, Arrow Lake support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     env:
       JOB_TYPE: BUILD
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: acidanthera/MacKernelSDK
           path: MacKernelSDK
@@ -33,7 +33,7 @@ jobs:
       - run: xcodebuild -jobs 1 -configuration Release
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/*/*.zip

--- a/CpuTopologyRebuild.xcodeproj/project.pbxproj
+++ b/CpuTopologyRebuild.xcodeproj/project.pbxproj
@@ -404,7 +404,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MARKETING_VERSION = "$(MODULE_VERSION)";
 				MODULE_NAME = org.vanilla.driver.CpuTopologyRebuild;
-				MODULE_VERSION = 1.1.1;
+				MODULE_VERSION = 2.0.0;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -453,7 +453,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MARKETING_VERSION = "$(MODULE_VERSION)";
 				MODULE_NAME = org.vanilla.driver.CpuTopologyRebuild;
-				MODULE_VERSION = 1.1.1;
+				MODULE_VERSION = 2.0.0;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",

--- a/CpuTopologyRebuild/CpuTopologyRebuild.cpp
+++ b/CpuTopologyRebuild/CpuTopologyRebuild.cpp
@@ -65,7 +65,10 @@ static void print_cpu_topology(void) {
     x86_core_t *core;
     x86_lcpu_t *lcpu;
 
-    SYSLOG("ctr", "CPU: physical_cpu_max=%d, logical_cpu_max=%d", machine_info.physical_cpu_max, machine_info.logical_cpu_max);
+    i386_cpu_info_t *info = cpuid_info();
+    SYSLOG("ctr", "CPU info:");
+    SYSLOG("ctr", "  physical_cpu_max = %2d | logical_cpu_max = %2d", machine_info.physical_cpu_max, machine_info.logical_cpu_max);
+    SYSLOG("ctr", "  core_count       = %2d | thread_count    = %2d", info->core_count, info->thread_count);
     SYSLOG("ctr", "Pkg->Die->Core->lcpu chain:");
     pkg = x86_pkgs;
     while (pkg != nullptr) {
@@ -145,7 +148,7 @@ static bool load_cpus(void) {
             for (int j = 0; j < APIC_ID_UNIT; j += 2) {
                 lcpu = lcpus_by_apic[i * APIC_ID_UNIT + j];
                 if (lcpu != nullptr) {
-                    SYSLOG("ctr", "Apic ID %02d -> E-Core", lcpu->pnum);
+                    SYSLOG("ctr", "ApicID %02d -> E-Core", lcpu->pnum);
                     e0_cpus[e0_count++] = lcpu;
                 }
             }
@@ -155,13 +158,13 @@ static bool load_cpus(void) {
             if (lcpu == nullptr) {
                 break;
             }
-            SYSLOG("ctr", "Apic ID %02d -> P-Core", lcpu->pnum);
+            SYSLOG("ctr", "ApicID %02d -> P-Core", lcpu->pnum);
             p0_cpus[p0_count++] = lcpu;
 
             // P-Core HT
             lcpu = lcpus_by_apic[i * APIC_ID_UNIT + 1];
             if (lcpu != nullptr) {
-                SYSLOG("ctr", "Apic ID %02d -> P-Core(HT)", lcpu->pnum);
+                SYSLOG("ctr", "ApicID %02d -> P-Core(HT)", lcpu->pnum);
                 p1_cpus[p1_count++] = lcpu;
             }
         }

--- a/CpuTopologyRebuild/CpuTopologyRebuild.cpp
+++ b/CpuTopologyRebuild/CpuTopologyRebuild.cpp
@@ -23,6 +23,18 @@ int e_core_first = -1;
 
 extern "C" void x86_validate_topology(void);
 extern "C" int kdb_printf_unbuffered(const char *fmt, ...);
+extern x86_topology_parameters_t topoParms;
+
+static void print_topo_parms(void) {
+    SYSLOG("ctr", "topoParms:");
+    SYSLOG("ctr", "  nPackages           = %3d", topoParms.nPackages);
+    SYSLOG("ctr", "  nPDiesPerPackage    = %3d | nLDiesPerPackage    = %3d", topoParms.nPDiesPerPackage, topoParms.nLDiesPerPackage);
+    SYSLOG("ctr", "  nPCoresPerPackage   = %3d | nLCoresPerPackage   = %3d", topoParms.nPCoresPerPackage, topoParms.nLCoresPerPackage);
+    SYSLOG("ctr", "  nPCoresPerDie       = %3d | nLCoresPerDie       = %3d", topoParms.nPCoresPerDie, topoParms.nLCoresPerDie);
+    SYSLOG("ctr", "  nPThreadsPerPackage = %3d | nLThreadsPerPackage = %3d", topoParms.nPThreadsPerPackage, topoParms.nLThreadsPerPackage);
+    SYSLOG("ctr", "  nPThreadsPerDie     = %3d | nLThreadsPerDie     = %3d", topoParms.nPThreadsPerDie, topoParms.nLThreadsPerDie);
+    SYSLOG("ctr", "  nPThreadsPerCore    = %3d | nLThreadsPerCore    = %3d", topoParms.nPThreadsPerCore, topoParms.nLThreadsPerCore);
+}
 
 static void print_lcpu_topology(x86_lcpu_t *lcpu) {
     SYSLOG("ctr", "      lcpu(%p): pnum=%2d, lnum=%2d, cpu_num=%2d, primary=%d, master=%d",
@@ -204,7 +216,7 @@ static void rebuild_cpu_topology(void) {
 }
 
 void my_x86_validate_topology(void) {
-    load_cpus();
+    print_topo_parms();
     SYSLOG("ctr", "---- CPU topology before rebuild ----");
     print_cpu_topology();
     if (print_only) {

--- a/CpuTopologyRebuild/CpuTopologyRebuild.cpp
+++ b/CpuTopologyRebuild/CpuTopologyRebuild.cpp
@@ -31,33 +31,33 @@ extern "C" void x86_validate_topology(void);
 extern x86_topology_parameters_t topoParms;
 
 static void print_topo_parms(void) {
-    SYSLOG("ctr", "topoParms:");
-    SYSLOG("ctr", "  nPackages           = %3d", topoParms.nPackages);
-    SYSLOG("ctr", "  nPDiesPerPackage    = %3d | nLDiesPerPackage    = %3d", topoParms.nPDiesPerPackage, topoParms.nLDiesPerPackage);
-    SYSLOG("ctr", "  nPCoresPerPackage   = %3d | nLCoresPerPackage   = %3d", topoParms.nPCoresPerPackage, topoParms.nLCoresPerPackage);
-    SYSLOG("ctr", "  nPCoresPerDie       = %3d | nLCoresPerDie       = %3d", topoParms.nPCoresPerDie, topoParms.nLCoresPerDie);
-    SYSLOG("ctr", "  nPThreadsPerPackage = %3d | nLThreadsPerPackage = %3d", topoParms.nPThreadsPerPackage, topoParms.nLThreadsPerPackage);
-    SYSLOG("ctr", "  nPThreadsPerDie     = %3d | nLThreadsPerDie     = %3d", topoParms.nPThreadsPerDie, topoParms.nLThreadsPerDie);
-    SYSLOG("ctr", "  nPThreadsPerCore    = %3d | nLThreadsPerCore    = %3d", topoParms.nPThreadsPerCore, topoParms.nLThreadsPerCore);
+    DBGLOG("ctr", "topoParms:");
+    DBGLOG("ctr", "  nPackages           = %3d", topoParms.nPackages);
+    DBGLOG("ctr", "  nPDiesPerPackage    = %3d | nLDiesPerPackage    = %3d", topoParms.nPDiesPerPackage, topoParms.nLDiesPerPackage);
+    DBGLOG("ctr", "  nPCoresPerPackage   = %3d | nLCoresPerPackage   = %3d", topoParms.nPCoresPerPackage, topoParms.nLCoresPerPackage);
+    DBGLOG("ctr", "  nPCoresPerDie       = %3d | nLCoresPerDie       = %3d", topoParms.nPCoresPerDie, topoParms.nLCoresPerDie);
+    DBGLOG("ctr", "  nPThreadsPerPackage = %3d | nLThreadsPerPackage = %3d", topoParms.nPThreadsPerPackage, topoParms.nLThreadsPerPackage);
+    DBGLOG("ctr", "  nPThreadsPerDie     = %3d | nLThreadsPerDie     = %3d", topoParms.nPThreadsPerDie, topoParms.nLThreadsPerDie);
+    DBGLOG("ctr", "  nPThreadsPerCore    = %3d | nLThreadsPerCore    = %3d", topoParms.nPThreadsPerCore, topoParms.nLThreadsPerCore);
 }
 
 static void print_lcpu_topology(x86_lcpu_t *lcpu) {
-    SYSLOG("ctr", "      lcpu(%p): pnum=%2d, lnum=%2d, cpu_num=%2d, primary=%d, master=%d",
+    DBGLOG("ctr", "      lcpu(%p): pnum=%2d, lnum=%2d, cpu_num=%2d, primary=%d, master=%d",
         lcpu, lcpu->pnum, lcpu->lnum, lcpu->cpu_num, lcpu->primary, lcpu->master);
 }
 
 static void print_core_topology(x86_core_t *core) {
-    SYSLOG("ctr", "    Core(%p): pcore_num=%2d, lcore_num=%2d, num_lcpus=%d",
+    DBGLOG("ctr", "    Core(%p): pcore_num=%2d, lcore_num=%2d, num_lcpus=%d",
         core, core->pcore_num, core->lcore_num, core->num_lcpus);
 }
 
 static void print_die_topology(x86_die_t *die) {
-    SYSLOG("ctr", "  Die(%p): pdie_num=%d, ldie_num=%d, num_cores=%2d",
+    DBGLOG("ctr", "  Die(%p): pdie_num=%d, ldie_num=%d, num_cores=%2d",
         die, die->pdie_num, die->ldie_num, die->num_cores);
 }
 
 static void print_pkg_topology(x86_pkg_t *pkg) {
-    SYSLOG("ctr", "Pkg(%p): ppkg_num=%d, lpkg_num=%d, num_dies=%d",
+    DBGLOG("ctr", "Pkg(%p): ppkg_num=%d, lpkg_num=%d, num_dies=%d",
         pkg, pkg->ppkg_num, pkg->lpkg_num, pkg->num_dies);
 }
 
@@ -68,10 +68,10 @@ static void print_cpu_topology(void) {
     x86_lcpu_t *lcpu;
 
     i386_cpu_info_t *info = cpuid_info();
-    SYSLOG("ctr", "CPU info:");
-    SYSLOG("ctr", "  physical_cpu_max = %2d | logical_cpu_max = %2d", machine_info.physical_cpu_max, machine_info.logical_cpu_max);
-    SYSLOG("ctr", "  core_count       = %2d | thread_count    = %2d", info->core_count, info->thread_count);
-    SYSLOG("ctr", "Pkg->Die->Core->lcpu chain:");
+    DBGLOG("ctr", "CPU info:");
+    DBGLOG("ctr", "  physical_cpu_max = %2d | logical_cpu_max = %2d", machine_info.physical_cpu_max, machine_info.logical_cpu_max);
+    DBGLOG("ctr", "  core_count       = %2d | thread_count    = %2d", info->core_count, info->thread_count);
+    DBGLOG("ctr", "Pkg->Die->Core->lcpu chain:");
     pkg = x86_pkgs;
     while (pkg != nullptr) {
         print_pkg_topology(pkg);
@@ -92,7 +92,7 @@ static void print_cpu_topology(void) {
         }
         pkg = pkg->next;
     }
-    SYSLOG("ctr", "Pkg->Die->lcpu chain:");
+    DBGLOG("ctr", "Pkg->Die->lcpu chain:");
     pkg = x86_pkgs;
     while (pkg != nullptr) {
         print_pkg_topology(pkg);
@@ -108,7 +108,7 @@ static void print_cpu_topology(void) {
         }
         pkg = pkg->next;
     }
-    SYSLOG("ctr", "Pkg->Core chain:");
+    DBGLOG("ctr", "Pkg->Core chain:");
     pkg = x86_pkgs;
     while (pkg != nullptr) {
         print_pkg_topology(pkg);
@@ -119,7 +119,7 @@ static void print_cpu_topology(void) {
         }
         pkg = pkg->next;
     }
-    SYSLOG("ctr", "Pkg->lcpu chain:");
+    DBGLOG("ctr", "Pkg->lcpu chain:");
     pkg = x86_pkgs;
     while (pkg != nullptr) {
         print_pkg_topology(pkg);
@@ -150,7 +150,7 @@ static bool load_cpus(void) {
             for (int j = 0; j < APIC_ID_UNIT; j += 2) {
                 lcpu = lcpus_by_apic[i * APIC_ID_UNIT + j];
                 if (lcpu != nullptr) {
-                    SYSLOG("ctr", "ApicID %02d -> E-Core", lcpu->pnum);
+                    DBGLOG("ctr", "ApicID %02d -> E-Core", lcpu->pnum);
                     e0_cpus[e0_count++] = lcpu;
                 }
             }
@@ -160,13 +160,13 @@ static bool load_cpus(void) {
             if (lcpu == nullptr) {
                 break;
             }
-            SYSLOG("ctr", "ApicID %02d -> P-Core", lcpu->pnum);
+            DBGLOG("ctr", "ApicID %02d -> P-Core", lcpu->pnum);
             p0_cpus[p0_count++] = lcpu;
 
             // P-Core HT
             lcpu = lcpus_by_apic[i * APIC_ID_UNIT + 1];
             if (lcpu != nullptr) {
-                SYSLOG("ctr", "ApicID %02d -> P-Core(HT)", lcpu->pnum);
+                DBGLOG("ctr", "ApicID %02d -> P-Core(HT)", lcpu->pnum);
                 p1_cpus[p1_count++] = lcpu;
             }
         }
@@ -269,13 +269,13 @@ static void rebuild_cpu_topology(void) {
 
 void my_x86_validate_topology(void) {
     print_topo_parms();
-    SYSLOG("ctr", "---- CPU topology before rebuild ----");
+    DBGLOG("ctr", "---- CPU topology before rebuild ----");
     print_cpu_topology();
     if (print_only) {
         return;
     }
     rebuild_cpu_topology();
-    SYSLOG("ctr", "---- CPU topology after rebuild ----");
+    DBGLOG("ctr", "---- CPU topology after rebuild ----");
     print_cpu_topology();
     // FunctionCast(my_x86_validate_topology, org_x86_validate_topology)(); // skip topology validation
 }

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Performance effect is currenlty uncertain.
 |NVRAM|boot-arg|Description|
 |-----|--------|-----------|
 |(none)|(none)|CPU topology will be spoofed as SMT to get better performance. E-Cores to be recognized as the N-way SMT logical threads of the P-Cores.<br>System Information show actual core count. (P+E)|
-|`ctrsmt` : `"off"`  |`ctrsmt=off` |No SMT spoofing. CPU topology will be same as real structure, but performance will be degraded.<br>Only works with Alder/Raptor Lake CPUs with HT enabled.<br>Same as v1.x.x default behavior.|
-|`ctrsmt` : `"full"` |`ctrsmt=full`|System Information shows # of P-Cores only. Performance effect is uncertain.<br>Same as v1.x.x with `-ctrsmt` behavior.|
+|`ctrsmt` : `"off"`  |`ctrsmt=off` |No SMT spoofing. CPU topology will be same as real structure, but performance will be degraded.<br>Only works with Alder/Raptor Lake CPUs with HT enabled.<br>Same as [v1.x.x](https://github.com/b00t0x/CpuTopologyRebuild/releases/tag/1.1.0) default behavior.|
+|`ctrsmt` : `"full"` |`ctrsmt=full`|System Information shows # of P-Cores only. Performance effect is uncertain.<br>Same as [v1.x.x](https://github.com/b00t0x/CpuTopologyRebuild/releases/tag/1.1.0) with `-ctrsmt` behavior.|
 |`ctrfixcnt` : `true`|`-ctrfixcnt` |Enable `machdep.cpu.core_count` fix. Performance effect is uncertain.<br>[AppleMCEReporterDisabler.kext](https://github.com/mikigal/ryzen-hackintosh/tree/master/OC/Kexts/AppleMCEReporterDisabler.kext) will be **required** to boot with this option.|
 
 ### Internal topology examples

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # CpuTopologyRebuild
-An **experimental** Lilu plugin that optimizes Alder Lake / Raptor Lake's heterogeneous core configuration.
+An Lilu plugin that optimizes Intel heterogeneous core configuration.
+
+Currently these generations are supported.
+* Alder Lake
+* Raptor Lake
+* Arrow Lake (experimental)
 
 For example, this kext is possible to recognize the Core i9-12900K's topology as 16 cores 24 threads or 8 cores 24 threads.
 
@@ -12,20 +17,30 @@ The effect of this kext is not yet clear, but I've seen not only a cosmetic effe
 Other examples : [Japanese](https://github.com/b00t0x/CpuTopologyRebuild/wiki/%E3%83%91%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%B3%E3%82%B9%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%8E%A8%E5%AF%9F) / [English(Translated)](https://github-com.translate.goog/b00t0x/CpuTopologyRebuild/wiki/%E3%83%91%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%B3%E3%82%B9%E3%81%AB%E9%96%A2%E3%81%99%E3%82%8B%E6%8E%A8%E5%AF%9F?_x_tr_sl=ja&_x_tr_tl=en)
 
 ### Usage
-* Use this kext with `ProvideCurrentCpuInfo` quirk.
-* `-ctrsmt` boot arg makes E-Cores to be recognized as the 3-way SMT logical threads of the P-Cores. For example, it is recognized as 8 cores 24 threads in Core i9. This option seems to give the closest single thread performance to E-Cores disabled configuration.
-* When HT disabled, E-Cores are recognized as a logical thread of P-Cores with or without `-ctrsmt`. 
+* For Alder Lake and Raptor Lake CPU, use this kext with `ProvideCurrentCpuInfo` quirk.
+  * Arrow Lake CPUs don't seem to require this quirk.
 
-### Topology examples
-|||ProvideCurrentCpuInfo|ProvideCurrentCpuInfo<br>+ CpuTopologyRebuild|ProvideCurrentCpuInfo<br>+ CpuTopologyRebuild<br>+ `-ctrsmt`|
+### Options
+Both boot-args and NVRAM (`4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102`) variables can be used.
+Performance effect is currenlty uncertain.
+|NVRAM|boot-arg|Description|
+|-----|--------|-----------|
+|(none)|(none)|CPU topology will be spoofed as SMT to get better performance. E-Cores to be recognized as the N-way SMT logical threads of the P-Cores.<br>System Information show actual core count. (P+E)|
+|`ctrsmt` : `"off"`  |`ctrsmt=off` |No SMT spoofing. CPU topology will be same as real structure, but performance will be degraded.<br>Only works with Alder/Raptor Lake CPUs with HT enabled.<br>Same as v1.x.x default behavior.|
+|`ctrsmt` : `"full"` |`ctrsmt=full`|System Information shows # of P-Cores only. Performance effect is uncertain.<br>Same as v1.x.x with `-ctrsmt` behavior.|
+|`ctrfixcnt` : `true`|`-ctrfixcnt` |Enable `machdep.cpu.core_count` fix. Performance effect is uncertain.<br>[AppleMCEReporterDisabler.kext](https://github.com/mikigal/ryzen-hackintosh/tree/master/OC/Kexts/AppleMCEReporterDisabler.kext) will be **required** to boot with this option.|
+
+### Internal topology examples
+|||Original|CpuTopologyRebuild<br>+ `ctrsmt=off`|CpuTopologyRebuild|
 |-|:-|-:|-:|-:|
-|Core i9-13900K|8P+16E+HT|32c32t|24c32t|8c32t|
-|Core i9-12900K|8P+8E+HT |24c24t|16c24t|8c24t|
-|              |8P+8E    |16c16t| 8c16t|8c16t|
-|Core i7-12700K|8P+4E+HT |20c20t|12c20t|8c20t|
-|              |8P+4E    |12c12t| 8c12t|8c12t|
-|Core i5-12600K|6P+4E+HT |16c16t|10c16t|6c16t|
-|              |6P+4E    |10c10t| 6c10t|6c10t|
+|Core i9-13900K   |8P+16E+HT|32c32t|24c32t|8c32t|
+|Core i9-12900K   |8P+8E+HT |24c24t|16c24t|8c24t|
+|                 |8P+8E    |16c16t| 8c16t|8c16t|
+|Core i7-12700K   |8P+4E+HT |20c20t|12c20t|8c20t|
+|                 |8P+4E    |12c12t| 8c12t|8c12t|
+|Core i5-12600K   |6P+4E+HT |16c16t|10c16t|6c16t|
+|                 |6P+4E    |10c10t| 6c10t|6c10t|
+|Core Ultra 9 285K|8P+16E   |24c24t| 8c24t|8c24t|
 
 ### About patches.plist
 #### patches_ht.plist
@@ -36,11 +51,12 @@ With `ProvideCurrentCpuInfo`, Hyper Threading is recognized as disabled due to t
 [patches_legacy.plist](patches_legacy.plist) can be used instead of `ProvideCurrentCpuInfo` quirk. It is not needed normally, but ProvideCurrentCpuInfo doesn't work for High Sierra and earlier, so you can use this patch for older macOS.
 
 ### Current problems
-* Changing the number of cores in cpuid info causes instability such as random boot failing, so it has not been changed now.
+* May cause random boot failure with verbose (`-v`) boot
 
 ### Credits
 - [Apple](https://www.apple.com) for macOS
 - [vit9696](https://github.com/vit9696) for original [CpuTopologySync](https://github.com/acidanthera/CpuTopologySync/tree/b2ce2619ea7e58ec4553ed3441aa03af6b771cdf)
 - [bootmacos](https://bootmacos.com/) for confirmation about Raptor Lake (i9-13900KF) and Ventura
 - [taruyato](https://github.com/taruyato) for confirmation 8P+4E configuration (i7-12700F) and Ventura ( #12 )
+- [AnaCarolina1980](https://github.com/AnaCarolina1980) for testing Arrow Lake CPU ( #22 )
 - [b00t0x](https://github.com/b00t0x) for writing the software and maintaining it

--- a/patches_ht.plist
+++ b/patches_ht.plist
@@ -7,12 +7,42 @@
 		<key>Patch</key>
 		<array>
 			<dict>
+					<key>Arch</key>
+					<string>Any</string>
+					<key>Base</key>
+					<string>_cpu_thread_alloc</string>
+					<key>Comment</key>
+					<string>force HT enabled for Sequoia or later</string>
+					<key>Count</key>
+					<integer>1</integer>
+					<key>Enabled</key>
+					<true/>
+					<key>Find</key>
+					<data>QYuGlAEAAA==</data>
+					<key>Identifier</key>
+					<string>kernel</string>
+					<key>Limit</key>
+					<integer>0</integer>
+					<key>Mask</key>
+					<data></data>
+					<key>MaxKernel</key>
+					<string></string>
+					<key>MinKernel</key>
+					<string>24.0.0</string>
+					<key>Replace</key>
+					<data>uP8AAACQkA==</data>
+					<key>ReplaceMask</key>
+					<data></data>
+					<key>Skip</key>
+					<integer>1</integer>
+			</dict>
+			<dict>
 				<key>Arch</key>
 				<string>Any</string>
 				<key>Base</key>
 				<string>_cpu_thread_alloc</string>
 				<key>Comment</key>
-				<string>force HT enabled for Mojave or later</string>
+				<string>force HT enabled for Mojave to Sonoma</string>
 				<key>Count</key>
 				<integer>1</integer>
 				<key>Enabled</key>
@@ -26,7 +56,7 @@
 				<key>Mask</key>
 				<data></data>
 				<key>MaxKernel</key>
-				<string></string>
+				<string>23.99.99</string>
 				<key>MinKernel</key>
 				<string>18.0.0</string>
 				<key>Replace</key>


### PR DESCRIPTION
## Summary
Almost rewrite
* Experimental Arrow Lake SMT spoofing support
* Remove cache structure rebuild implementation
  * because the effect is unclear
* System Information app shows all physical core count by default
  * can change by `ctrsmt=full` option
* Fix `machdep.cpu.core_count` by `-ctrfixcnt`
  * but AppleMCEReporterDisabler.kext required

## Issues
* closes #22
* closes #15 
  * Because I tested this build on Erying ITX i7-12700H